### PR TITLE
Group scripture spotlights and add translation tooltips

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
-# open-invitation
-God calls us with an open invitation into his kingdom, come explore the evidence!
+# Open Invitation Scripture Explorer
+
+Open Invitation is a static site experience that invites visitors to explore how Scripture presents God’s call as an open, responsive invitation. The project emphasizes that faith comes by hearing the gospel rather than by secret regeneration, highlighting twenty foundational passages with narrative storytelling and exegetical commentary.
+
+## Getting Started
+1. Open `index.html` in your browser to view the landing page.
+2. Follow any Scripture link (for example, `scripture.html?id=romans-10-17`) to dive into the contextual study and commentary.
+3. Content is driven from `src/data/scriptures.js`, making it simple to add new passages or adjust analysis.
+
+## Project Structure
+- `docs/PLAN.md` – Project vision, goals, and roadmap.
+- `index.html` – Landing page with narrative timeline and scripture spotlights.
+- `scripture.html` – Scripture explorer page rendering context and commentary for a selected passage.
+- `src/data/scriptures.js` – Scripture dataset including references, context, and analysis.
+- `src/scripts/` – JavaScript modules for rendering the landing page and scripture explorer.
+- `src/styles/` – Global, layout, and component styles.
+
+## Adding More Passages
+1. Create a new object in `src/data/scriptures.js` following the existing schema.
+2. Add the passage’s `id` to any sections that should feature it (e.g., narrative timeline, hero highlights) within `src/scripts/index.js`.
+3. The new passage automatically appears in the Scripture Spotlights grid and becomes available through `scripture.html?id=your-id`.
+
+## Future Enhancements
+- Add search and filtering for quick navigation through passages.
+- Integrate audio narration for each study.
+- Provide downloadable study guides and group discussion prompts.
+
+Contributions are welcome! Please review the plan document for guiding principles before submitting updates.

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -1,0 +1,101 @@
+# Project Plan: Open Invitation Scripture Explorer
+
+## Vision and Goals
+- Present a welcoming, engaging experience that invites visitors to explore Scripture from a dynamic omniscience, non-Calvinist perspective.
+- Emphasize that faith comes through hearing the Word, not through pre-regeneration, by highlighting relevant passages and analysis.
+- Provide easily extendable content structures so new passages, commentary, and media can be added without reworking core layouts.
+
+## Audience and Tone
+- Primary audience: Christians curious about the Ordo Salutis debate, especially those questioning deterministic frameworks.
+- Tone: Warm, narrative-driven, hopeful, and rooted in Scripture. Visuals should feel uplifting and exploratory.
+
+## Information Architecture
+1. **Landing Page (`index.html`)**
+   - Hero section introducing the "Open Invitation" theme.
+   - Narrative timeline illustrating God's redemptive plan from creation to the present, focused on responsive relationship rather than determinism.
+   - Scripture spotlights embedded within the narrative, linking to deeper studies.
+   - Call-to-action blocks guiding visitors to explore Scripture studies, subscribe for updates, or participate in community discussions (future feature placeholder).
+2. **Scripture Explorer Page (`scripture.html`)**
+   - Displays selected passage with surrounding context, highlighting the focal verses.
+   - Provides structured commentary: textual observations, theological reflections, and application points.
+   - Sidebar for related passages, thematic tags, and navigation between studies.
+3. **Shared Components**
+   - Persistent header/footer with brand identity and navigation.
+   - Data-driven rendering using a shared `scriptures.js` dataset.
+
+## Content Model
+Each scripture entry will include:
+- `id`: unique slug used in URLs.
+- `reference`: human-readable reference (e.g., "Romans 10:17").
+- `translation`: translation label (e.g., "ESV").
+- `focus`: verses that are emphasized.
+- `context`: extended passage text for context.
+- `keyVerse`: the exact focus verse text.
+- `theme`: tags like "Faith", "Hearing", "Responsibility", "Call".
+- `summary`: high-level takeaway for landing-page cards.
+- `analysis`: array of commentary sections (title + body) to present in the explorer.
+- `links`: additional resources (optional for future expansion).
+
+## Initial Scripture Set (20 Passages)
+1. Romans 10:17
+2. Romans 10:14-15
+3. John 20:30-31
+4. Acts 2:37-38
+5. Acts 10:43-48
+6. Acts 13:46-48
+7. Acts 16:30-34
+8. Hebrews 4:2
+9. Hebrews 11:6
+10. Galatians 3:2-5
+11. Ephesians 1:13-14
+12. James 1:18-21
+13. 1 Peter 1:22-25
+14. Revelation 3:20
+15. Isaiah 55:1-3
+16. Jeremiah 7:23-28
+17. Ezekiel 18:30-32
+18. Deuteronomy 30:11-20
+19. 2 Corinthians 5:18-21
+20. 1 Timothy 2:3-6
+
+These passages will either be woven into the landing-page narrative or linked through callouts and the explorer sidebar.
+
+## Visual and Interaction Design
+- **Color Palette**: Warm gradients (sunrise hues), deep navy accents, light neutrals for readability.
+- **Typography**: Friendly sans-serif for UI, serif for scripture text to provide reverence and contrast.
+- **Imagery**: Abstract shapes, subtle textures reminiscent of illuminated manuscripts; no heavy photography to maintain focus on text.
+- **Animations**: Soft fade-ins and scroll-triggered reveals for narrative sections (initial implementation via CSS transitions; future enhancement via Intersection Observer).
+
+## Technical Approach
+- Static HTML/CSS/JS for portability and simplicity.
+- Central data file `src/data/scriptures.js` exporting an array of passage objects.
+- Landing page script (`src/scripts/index.js`) dynamically injects featured passages into narrative callouts.
+- Scripture explorer script (`src/scripts/scripture.js`) reads query parameters (`?id=`) to load matching data and render context/analysis.
+- Utility functions for formatting and navigation located in `src/scripts/utils.js` for reuse.
+- Styles split into global (`src/styles/global.css`), layout (`src/styles/layout.css`), and component-specific modules (`src/styles/components.css`).
+
+## Extensibility Strategy
+- New passages can be appended to `scriptures.js` with minimal friction.
+- Narrative sections reference scriptures by ID; future updates only require dataset changes, not markup rewrites.
+- Analysis sections stored as arrays allow adding multiple commentary points without altering templates.
+- Placeholder components for upcoming features (newsletter, discussion prompts) are documented for later activation.
+
+## Implementation Roadmap
+1. **Phase 1 (Current)**
+   - Establish project structure and base styles.
+   - Implement landing page with narrative sections and scripture callouts.
+   - Build scripture explorer page with context highlighting and commentary layout.
+   - Populate initial 20 scripture entries with summarized analysis.
+2. **Phase 2**
+   - Add client-side routing enhancements or SPA framework if needed.
+   - Integrate search/filtering for passages.
+   - Add multimedia elements (audio readings, timeline illustrations).
+3. **Phase 3**
+   - Implement user engagement features (newsletter signup, community testimonies).
+   - Incorporate backend or CMS for collaborative content updates.
+
+## Documentation and Maintenance
+- Update README with project overview, setup instructions, and contribution guidelines.
+- Maintain changelog for future iterations.
+- Encourage theological review by trusted advisors before publishing new commentary.
+

--- a/index.html
+++ b/index.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Open Invitation | Faith Comes by Hearing</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&family=Poppins:wght@400;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="src/styles/global.css">
+  <link rel="stylesheet" href="src/styles/layout.css">
+  <link rel="stylesheet" href="src/styles/components.css">
+</head>
+<body>
+  <header class="header">
+    <div class="header-inner">
+      <a class="brand" href="index.html">Open Invitation</a>
+      <nav class="nav-links">
+        <a href="#story">Story</a>
+        <a href="#spotlights">Scripture Spotlights</a>
+        <a href="#next-steps">Next Steps</a>
+      </nav>
+    </div>
+  </header>
+  <main>
+    <section class="hero" id="top">
+      <div class="hero-glow"></div>
+      <div class="hero-content">
+        <div class="badge">Faith Comes by Hearing</div>
+        <h1>Discover God's responsive call—and why the gospel invites a real decision.</h1>
+        <p>
+          Journey through Scripture to see how God proclaims good news, calls all people to respond,
+          and entrusts the Spirit to seal those who believe. Explore passages that celebrate divine
+          initiative and genuine human response—pushing back on deterministic assumptions about the
+          order of salvation.
+        </p>
+        <div class="hero-actions">
+          <a href="#story"><button>Walk the Story</button></a>
+          <a href="#spotlights"><button style="background: #fff; color: var(--color-primary);">Explore Passages</button></a>
+        </div>
+        <div class="hero-grid" id="hero-grid"></div>
+      </div>
+    </section>
+
+    <section class="section" id="story">
+      <div class="section-inner">
+        <p class="section-eyebrow">Narrative</p>
+        <h2>The Living Story of God's Invitation</h2>
+        <p>
+          Scripture recounts a God who knows every possibility and engages creation with love, warning,
+          promise, and genuine appeals. Follow the arc—from prophetic calls to apostolic proclamation—
+          and see how hearing and believing sit at the heart of salvation.
+        </p>
+        <div class="timeline" id="timeline"></div>
+      </div>
+    </section>
+
+    <section class="section" id="spotlights">
+      <div class="section-inner">
+        <p class="section-eyebrow">Scripture Spotlights</p>
+        <h2>Passages that Illuminate Faith's Response</h2>
+        <p>
+          Dive deeper into twenty studies focused on the call to hear, believe, repent, and cling to Christ.
+          Each entry includes full context and exegetical reflections crafted to engage the Ordo Salutis conversation.
+        </p>
+        <div class="spotlight-groups" id="spotlight-grid"></div>
+      </div>
+    </section>
+
+    <section class="section" id="next-steps">
+      <div class="section-inner">
+        <div class="banner">
+          <h2>Keep Listening for the Spirit's Whisper</h2>
+          <p>
+            We are preparing resources for group studies, teaching outlines, and testimony videos that
+            highlight how the gospel transforms hearts through hearing. Want to stay updated?
+          </p>
+          <div class="hero-actions" style="margin-top: 1.5rem;">
+            <button disabled title="Coming soon">Community Launch (Soon)</button>
+            <a href="#spotlights"><button style="background: #fff; color: var(--color-primary);">Review the Scriptures Again</button></a>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <div class="footer-inner">
+      <strong>Open Invitation</strong>
+      <p>
+        Celebrating the gospel call that invites everyone to hear, believe, and be sealed by the Spirit.
+        Built to help you examine Scripture deeply and joyfully.
+      </p>
+      <div class="footer-links">
+        <a href="#top">Back to top</a>
+        <a href="scripture.html?id=romans-10-17">Romans 10:17 Study</a>
+        <a href="scripture.html?id=acts-2-37-38">Acts 2:37-38 Study</a>
+      </div>
+    </div>
+  </footer>
+
+  <script type="module" src="src/scripts/index.js"></script>
+</body>
+</html>

--- a/scripture.html
+++ b/scripture.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Scripture Explorer | Open Invitation</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@400;700&family=Poppins:wght@400;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="src/styles/global.css">
+  <link rel="stylesheet" href="src/styles/layout.css">
+  <link rel="stylesheet" href="src/styles/components.css">
+</head>
+<body>
+  <header class="header">
+    <div class="header-inner">
+      <a class="brand" href="index.html">Open Invitation</a>
+      <nav class="nav-links">
+        <a href="index.html#story">Story</a>
+        <a href="index.html#spotlights">Scripture Spotlights</a>
+        <a href="index.html#next-steps">Next Steps</a>
+      </nav>
+    </div>
+  </header>
+  <main class="section">
+    <div class="section-inner">
+      <a class="back-link" href="index.html#spotlights">← Back to all passages</a>
+      <div class="scripture-layout" id="scripture-layout">
+        <div class="scripture-body" id="scripture-body">
+          <div class="text-muted">Loading passage…</div>
+        </div>
+        <aside class="sidebar" id="sidebar"></aside>
+      </div>
+    </div>
+  </main>
+  <footer class="footer">
+    <div class="footer-inner">
+      <strong>Open Invitation</strong>
+      <p>Keep walking in the light you have received—share the invitation with someone today.</p>
+    </div>
+  </footer>
+  <script type="module" src="src/scripts/scripture.js"></script>
+</body>
+</html>

--- a/src/data/scriptures.js
+++ b/src/data/scriptures.js
@@ -1,0 +1,576 @@
+const scriptures = [
+  {
+    id: 'romans-10-17',
+    reference: 'Romans 10:17',
+    title: 'Faith Comes by Hearing Christ',
+    translation: 'World English Bible',
+    summary: 'Paul insists that faith springs from hearing the proclaimed word about Christ.',
+    keyVerse: 'So faith comes by hearing, and hearing by the word of Christ.',
+    themes: ['Faith', 'Hearing', 'Mission', 'Responsibility'],
+    category: 'Hear and Believe',
+    context: [
+      {
+        heading: 'Romans 10:14-17',
+        text: `How then will they call on him in whom they have not believed? How will they believe in him whom they have not heard? How will they hear without a preacher? And how will they preach unless they are sent? As it is written: "How beautiful are the feet of those who preach the Good News of peace, who bring glad tidings of good things!" But they didn't all listen to the glad news. For Isaiah says, "Lord, who has believed our report?" <span class="focus-text">So faith comes by hearing, and hearing by the word of Christ.</span>`
+      }
+    ],
+    analysis: [
+      {
+        title: 'Hearing Precedes Faith',
+        body: 'Paul traces faith back to proclamation. The logic collapses if hearing is not the means by which belief is birthed. Regeneration is not inserted before hearing; the Spirit works through the preached word.'
+      },
+      {
+        title: 'Mission Matters',
+        body: 'The cascading questions—sent ones, preaching, hearing, believing—show God partnering with responsive messengers. Determinism would make these steps unnecessary, but Paul roots salvation in the real-world dynamics of proclamation.'
+      }
+    ]
+  },
+  {
+    id: 'romans-10-14-15',
+    reference: 'Romans 10:14-15',
+    title: 'Sent Voices Carry the Invitation',
+    translation: 'World English Bible',
+    summary: 'Without proclamation, people cannot believe; God enlists messengers to carry the good news.',
+    keyVerse: 'How then will they call on him in whom they have not believed? ... How will they hear without a preacher?',
+    themes: ['Mission', 'Responsibility', 'Faith'],
+    category: 'Mission & Mediation',
+    context: [
+      {
+        heading: 'Romans 10:14-15',
+        text: `<span class="focus-text">How then will they call on him in whom they have not believed? How will they believe in him whom they have not heard? How will they hear without a preacher? And how will they preach unless they are sent?</span> As it is written: "How beautiful are the feet of those who preach the Good News of peace, who bring glad tidings of good things!"`
+      }
+    ],
+    analysis: [
+      {
+        title: 'Real Dependency on Witnesses',
+        body: 'Paul reasons that belief depends on the tangible act of hearing the gospel. The sending of heralds is not a mere formality; it is God’s ordained means to awaken faith.'
+      },
+      {
+        title: 'Collaborators with God',
+        body: 'The question sequence elevates human participation. God sovereignly chooses to involve real people whose obedience or silence affects who hears. This affirms contingency rather than inevitability.'
+      }
+    ]
+  },
+  {
+    id: 'john-20-30-31',
+    reference: 'John 20:30-31',
+    title: 'Written Testimony for Believing Life',
+    translation: 'World English Bible',
+    summary: 'John declares that his gospel is written so readers may believe and have life in Jesus’ name.',
+    keyVerse: 'These are written, that you may believe that Jesus is the Christ, the Son of God; and that believing you may have life in his name.',
+    themes: ['Faith', 'Testimony', 'Life'],
+    category: 'Hear and Believe',
+    context: [
+      {
+        heading: 'John 20:30-31',
+        text: `Therefore Jesus did many other signs in the presence of his disciples, which are not written in this book; but <span class="focus-text">these are written, that you may believe that Jesus is the Christ, the Son of God; and that believing you may have life in his name.</span>`
+      }
+    ],
+    analysis: [
+      {
+        title: 'Scripture as Faith-Creating Witness',
+        body: 'John expects the narrative itself to spark belief. The goal of writing is conversion, not merely confirmation of the already regenerated. The Spirit works through testimony to grant life.'
+      },
+      {
+        title: 'Believing Leads to Life',
+        body: 'Life is tied to believing, not the other way around. Regeneration does not cause belief in this text; instead, belief is the pathway to receiving life in Jesus’ name.'
+      }
+    ]
+  },
+  {
+    id: 'acts-2-37-38',
+    reference: 'Acts 2:37-38',
+    title: 'Pierced by the Word, Responding in Repentance',
+    translation: 'World English Bible',
+    summary: 'At Pentecost the crowd hears, is cut to the heart, and responds to the call to repent and be baptized.',
+    keyVerse: 'Now when they heard this, they were cut to the heart... Peter said to them, "Repent, and be baptized..."',
+    themes: ['Repentance', 'Spirit', 'Hearing', 'Community'],
+    category: 'Respond in Faith',
+    context: [
+      {
+        heading: 'Acts 2:32-41',
+        text: `"This Jesus God raised up, to which we all are witnesses. Therefore being exalted by the right hand of God, and having received from the Father the promise of the Holy Spirit, he has poured out this, which you now see and hear." Now when they heard this, they were cut to the heart, and said to Peter and the rest of the apostles, "Brothers, what shall we do?" <span class="focus-text">Peter said to them, "Repent, and be baptized, every one of you, in the name of Jesus Christ for the forgiveness of sins, and you will receive the gift of the Holy Spirit."</span> ... Then those who gladly received his word were baptized. There were added that day about three thousand souls.`
+      }
+    ],
+    analysis: [
+      {
+        title: 'Hearing Precedes Conviction',
+        body: 'The crowd is cut to the heart when they hear the sermon. The Spirit wields Peter’s proclamation to awaken repentance—not a hidden regeneration before the message.'
+      },
+      {
+        title: 'Conditional Promise',
+        body: 'The call is to repent and be baptized in order to receive forgiveness and the Holy Spirit. The promise is attached to response, affirming that God honors genuine repentance born of hearing.'
+      }
+    ]
+  },
+  {
+    id: 'acts-10-43-48',
+    reference: 'Acts 10:43-48',
+    title: 'Gentiles Receive the Spirit While Hearing',
+    translation: 'World English Bible',
+    summary: 'As Peter proclaims forgiveness through Jesus, the Spirit falls on those hearing the message.',
+    keyVerse: 'While Peter was still speaking these words, the Holy Spirit fell on all those who heard the word.',
+    themes: ['Spirit', 'Inclusion', 'Hearing'],
+    category: 'Spirit & New Life',
+    context: [
+      {
+        heading: 'Acts 10:39-48',
+        text: `"We are witnesses of everything he did both in the country of the Jews, and in Jerusalem... All the prophets testify about him, that through his name everyone who believes in him will receive remission of sins." <span class="focus-text">While Peter was still speaking these words, the Holy Spirit fell on all those who heard the word.</span> They of the circumcision who believed were amazed... Then Peter answered, "Can anyone forbid these people from being baptized with water? They have received the Holy Spirit just like us!"`
+      }
+    ],
+    analysis: [
+      {
+        title: 'Spirit Honors Hearing Faith',
+        body: 'The Spirit falls precisely as the word is spoken and heard. The narrative resists any chronology that places new birth before hearing the gospel.'
+      },
+      {
+        title: 'Belief is the Stated Condition',
+        body: 'Peter explicitly says everyone who believes receives forgiveness. The Spirit’s arrival ratifies that Gentiles believed while hearing, not prior to it.'
+      }
+    ]
+  },
+  {
+    id: 'acts-13-46-48',
+    reference: 'Acts 13:46-48',
+    title: 'Turning to the Gentiles with Good News',
+    translation: 'World English Bible',
+    summary: 'Paul and Barnabas confront rejection and celebrate Gentiles who believe unto eternal life.',
+    keyVerse: 'As many as were disposed to eternal life believed.',
+    themes: ['Mission', 'Responsibility', 'Gentiles'],
+    category: 'Hear and Believe',
+    context: [
+      {
+        heading: 'Acts 13:44-48',
+        text: `The next Sabbath almost the whole city was gathered together to hear the word of God. But when the Jews saw the multitudes, they were filled with jealousy... Paul and Barnabas spoke out boldly, and said, "It was necessary that God's word should be spoken to you first. Since indeed you thrust it from you... we turn to the Gentiles." ... <span class="focus-text">As many as were disposed to eternal life believed.</span>`
+      }
+    ],
+    analysis: [
+      {
+        title: 'Hearing Creates a Fork in the Road',
+        body: 'Both Jews and Gentiles hear. Some thrust the message away; others embrace it. The determining factor is the response to hearing, not an irresistible decree.'
+      },
+      {
+        title: 'Disposed Through the Word',
+        body: 'The phrase "disposed to eternal life" aligns with those who welcomed the message. Luke highlights receptivity formed by God’s persuasive word, not an unilateral regeneration prior to preaching.'
+      }
+    ]
+  },
+  {
+    id: 'acts-16-30-34',
+    reference: 'Acts 16:30-34',
+    title: 'Believe in the Lord Jesus and Be Saved',
+    translation: 'World English Bible',
+    summary: 'The Philippian jailer hears the gospel, believes with his household, and rejoices in newfound faith.',
+    keyVerse: 'Believe in the Lord Jesus Christ, and you will be saved, you and your household.',
+    themes: ['Faith', 'Households', 'Joy'],
+    category: 'Respond in Faith',
+    context: [
+      {
+        heading: 'Acts 16:29-34',
+        text: `He called for lights, sprang in, fell down trembling before Paul and Silas, and brought them out and said, "Sirs, what must I do to be saved?" They said, <span class="focus-text">"Believe in the Lord Jesus Christ, and you will be saved, you and your household."</span> They spoke the word of the Lord to him, and to all who were in his house. He took them the same hour of the night, and washed their stripes; and was immediately baptized, he and all his household. He brought them up into his house, set food before them, and rejoiced greatly, with all his household, having believed in God.`
+      }
+    ],
+    analysis: [
+      {
+        title: 'Direct Appeal to Believe',
+        body: 'Paul answers the jailer’s question with a clear directive: believe. The gospel word is then spoken to the whole household, indicating faith arises from hearing the message explained.'
+      },
+      {
+        title: 'Joy Follows Belief',
+        body: 'The household rejoices after believing. Salvation and joy are linked to their response of faith, not a secret work prior to their hearing of the word.'
+      }
+    ]
+  },
+  {
+    id: 'hebrews-4-2',
+    reference: 'Hebrews 4:2',
+    title: 'The Message Profits Those Who Combine Hearing with Faith',
+    translation: 'World English Bible',
+    summary: 'Good news must be mixed with faith in those who hear; otherwise it does not benefit them.',
+    keyVerse: 'The word they heard didn’t profit them, because it wasn’t mixed with faith in those who heard.',
+    themes: ['Faith', 'Warning', 'Responsibility'],
+    category: 'Hear and Believe',
+    context: [
+      {
+        heading: 'Hebrews 4:1-3',
+        text: `Let us fear therefore, lest perhaps anyone of you should seem to have come short of a promise of entering into his rest. <span class="focus-text">For indeed we have had good news preached to us, even as they also did; but the word they heard didn't profit them, because it wasn't mixed with faith in those who heard.</span> For we who have believed enter into that rest.`
+      }
+    ],
+    analysis: [
+      {
+        title: 'Hearing Can Be Fruitless',
+        body: 'The warning acknowledges that some hear without faith. If regeneration preceded hearing, the word would always profit. Instead, faith must be the response to the message.'
+      },
+      {
+        title: 'Belief Grants Rest',
+        body: 'Those who believe enter rest. The sequence underscores that rest follows faith, which follows hearing.'
+      }
+    ]
+  },
+  {
+    id: 'hebrews-11-6',
+    reference: 'Hebrews 11:6',
+    title: 'Without Faith It Is Impossible to Please God',
+    translation: 'World English Bible',
+    summary: 'Faith is required to approach God; one must believe He exists and rewards seekers.',
+    keyVerse: 'Without faith it is impossible to be well pleasing to him.',
+    themes: ['Faith', 'Seeking', 'Reward'],
+    category: 'Accountability & Awakening',
+    context: [
+      {
+        heading: 'Hebrews 11:5-6',
+        text: `By faith, Enoch was taken away so that he wouldn't see death... <span class="focus-text">Without faith it is impossible to be well pleasing to him; for he who comes to God must believe that he exists, and that he is a rewarder of those who seek him.</span>`
+      }
+    ],
+    analysis: [
+      {
+        title: 'Faith is Prerequisite to Nearness',
+        body: 'The author insists that anyone who comes must believe. The requirement sits on the human side of the relationship, not on a hidden pre-faith regeneration.'
+      },
+      {
+        title: 'God Rewards Seekers',
+        body: 'The verse affirms genuine seeking. God responds to those who seek Him, undercutting deterministic assumptions that deny meaningful pursuit.'
+      }
+    ]
+  },
+  {
+    id: 'galatians-3-2-5',
+    reference: 'Galatians 3:2-5',
+    title: 'The Spirit Received by Hearing with Faith',
+    translation: 'World English Bible',
+    summary: 'Paul reminds the Galatians that they received the Spirit through hearing with faith, not by works.',
+    keyVerse: 'Did you receive the Spirit by the works of the law, or by hearing of faith?',
+    themes: ['Spirit', 'Faith', 'Grace'],
+    category: 'Spirit & New Life',
+    context: [
+      {
+        heading: 'Galatians 3:1-5',
+        text: `Foolish Galatians, who has bewitched you... This only I desire to learn from you: <span class="focus-text">Did you receive the Spirit by the works of the law, or by hearing of faith?</span> Are you so foolish? Having begun in the Spirit, are you now completed in the flesh?`
+      }
+    ],
+    analysis: [
+      {
+        title: 'Experience Confirms the Order',
+        body: 'Paul appeals to their own experience: the Spirit came through hearing with faith. This historical fact undermines any claim that regeneration preceded their believing response.'
+      },
+      {
+        title: 'Hearing with Faith Versus Works',
+        body: 'The contrast is between hearing with faith and law-keeping. The Spirit honors trusting reception of the message, not meritorious effort nor irresistible decrees.'
+      }
+    ]
+  },
+  {
+    id: 'ephesians-1-13-14',
+    reference: 'Ephesians 1:13-14',
+    title: 'Hearing, Believing, Sealed with the Spirit',
+    translation: 'World English Bible',
+    summary: 'Believers are sealed with the Spirit after hearing the gospel and believing in Christ.',
+    keyVerse: 'Having heard the word of truth, the Good News of your salvation—in whom, having also believed, you were sealed with the promised Holy Spirit.',
+    themes: ['Spirit', 'Assurance', 'Faith'],
+    category: 'Spirit & New Life',
+    context: [
+      {
+        heading: 'Ephesians 1:11-14',
+        text: `In him we were assigned as a heritage... <span class="focus-text">In whom you also, having heard the word of truth, the Good News of your salvation—in whom, having also believed, you were sealed with the promised Holy Spirit.</span> He is a pledge of our inheritance, to the redemption of God's own possession.`
+      }
+    ],
+    analysis: [
+      {
+        title: 'Clear Sequence of Salvation',
+        body: 'Paul lists hearing, believing, then sealing. The Spirit seals after faith, not before. The Ordo Salutis here contradicts a regeneration-before-faith model.'
+      },
+      {
+        title: 'The Gospel is the Instrument',
+        body: 'The "word of truth" is the means God uses. No secret knowledge is required—just the proclaimed gospel embraced by faith.'
+      }
+    ]
+  },
+  {
+    id: 'james-1-18-21',
+    reference: 'James 1:18-21',
+    title: 'Receive the Implanted Word',
+    translation: 'World English Bible',
+    summary: 'James urges believers to receive the implanted word with meekness because it can save their souls.',
+    keyVerse: 'Receive with meekness the implanted word, which is able to save your souls.',
+    themes: ['Word', 'Responsibility', 'Holiness'],
+    category: 'Spirit & New Life',
+    context: [
+      {
+        heading: 'James 1:18-22',
+        text: `Of his own will he brought us forth by the word of truth... Therefore, putting away all filthiness and overflowing wickedness, <span class="focus-text">receive with meekness the implanted word, which is able to save your souls.</span> But be doers of the word, and not only hearers, deluding your own selves.`
+      }
+    ],
+    analysis: [
+      {
+        title: 'God Births by the Word',
+        body: 'James credits God with bringing us forth through the word, not apart from it. The word is the instrument, calling for receptive hearts.'
+      },
+      {
+        title: 'Ongoing Reception Required',
+        body: 'Believers must keep receiving the word. Salvation is tied to meekly embracing what is spoken, underscoring ongoing responsiveness.'
+      }
+    ]
+  },
+  {
+    id: '1-peter-1-22-25',
+    reference: '1 Peter 1:22-25',
+    title: 'Born Again Through the Living Word',
+    translation: 'World English Bible',
+    summary: 'Peter ties new birth to the living and abiding word of God that was preached to believers.',
+    keyVerse: 'Having been born again, not of corruptible seed, but of incorruptible, through the word of God.',
+    themes: ['New Birth', 'Word', 'Love'],
+    category: 'Spirit & New Life',
+    context: [
+      {
+        heading: '1 Peter 1:22-25',
+        text: `Seeing you have purified your souls in your obedience to the truth... <span class="focus-text">Having been born again, not of corruptible seed, but of incorruptible, through the word of God, which lives and remains forever.</span> ... This is the word of Good News which was preached to you.`
+      }
+    ],
+    analysis: [
+      {
+        title: 'New Birth via the Word',
+        body: 'Peter explicitly connects new birth to the preached word. Regeneration happens through, not prior to, hearing the gospel message.'
+      },
+      {
+        title: 'Obedience to the Truth',
+        body: 'Purifying souls comes through obeying the truth. Faithful response is part of the process, indicating real agency.'
+      }
+    ]
+  },
+  {
+    id: 'revelation-3-20',
+    reference: 'Revelation 3:20',
+    title: 'Jesus Knocks and Awaits Response',
+    translation: 'World English Bible',
+    summary: 'The risen Christ stands at the door and knocks, inviting any who hear and open to dine with Him.',
+    keyVerse: 'Behold, I stand at the door and knock. If anyone hears my voice and opens the door, I will come in to him.',
+    themes: ['Invitation', 'Fellowship', 'Responsibility'],
+    category: 'Respond in Faith',
+    context: [
+      {
+        heading: 'Revelation 3:19-21',
+        text: `"As many as I love, I reprove and chasten. Be zealous therefore, and repent. <span class="focus-text">Behold, I stand at the door and knock. If anyone hears my voice and opens the door, then I will come in to him, and will dine with him, and he with me.</span> He who overcomes, I will give to him to sit down with me on my throne."`
+      }
+    ],
+    analysis: [
+      {
+        title: 'Conditional Fellowship',
+        body: 'Jesus waits for the door to be opened. The promise hinges on hearing and responding, supporting a dynamic relationship rather than automatic entrance.'
+      },
+      {
+        title: 'Call to Repent',
+        body: 'Repentance is urged alongside the invitation, showing that hearing His voice invites tangible change.'
+      }
+    ]
+  },
+  {
+    id: 'isaiah-55-1-3',
+    reference: 'Isaiah 55:1-3',
+    title: 'Come, Everyone Who Thirsts',
+    translation: 'World English Bible',
+    summary: 'God pleads with the thirsty to come, listen diligently, and live.',
+    keyVerse: 'Incline your ear, and come to me. Hear, and your soul will live.',
+    themes: ['Invitation', 'Grace', 'Hearing'],
+    category: 'Respond in Faith',
+    context: [
+      {
+        heading: 'Isaiah 55:1-3',
+        text: `"Come, everyone who thirsts, to the waters! Come, you who have no money, buy, and eat... <span class="focus-text">Incline your ear, and come to me. Hear, and your soul will live.</span> I will make an everlasting covenant with you, even the sure mercies of David."`
+      }
+    ],
+    analysis: [
+      {
+        title: 'Universal Invitation',
+        body: 'The call is extended to everyone who thirsts. The only requirement is to come and listen—underscoring the openness of God’s offer.'
+      },
+      {
+        title: 'Hearing Brings Life',
+        body: 'Life is promised to those who hear. The emphasis mirrors the New Testament teaching that faith and life come through hearing God’s word.'
+      }
+    ]
+  },
+  {
+    id: 'jeremiah-7-23-28',
+    reference: 'Jeremiah 7:23-28',
+    title: 'They Would Not Listen',
+    translation: 'World English Bible',
+    summary: 'Despite God’s persistent pleas, Judah refused to obey or incline their ear.',
+    keyVerse: 'They didn’t listen to me or incline their ear, but made their neck stiff.',
+    themes: ['Warning', 'Responsibility', 'Prophets'],
+    category: 'Accountability & Awakening',
+    context: [
+      {
+        heading: 'Jeremiah 7:23-28',
+        text: `"Obey my voice, and I will be your God, and you shall be my people; walk in all the way that I command you, that it may be well with you." <span class="focus-text">But they didn't listen to me or incline their ear, but walked in their own counsels and in the stubbornness of their evil heart.</span> ... "Truth has perished."`
+      }
+    ],
+    analysis: [
+      {
+        title: 'God Desires Obedient Hearing',
+        body: 'The covenant promise hinges on listening. Israel’s refusal shows that human response matters and can thwart the blessings God longs to give.'
+      },
+      {
+        title: 'Persistent Prophetic Appeal',
+        body: 'God sent prophets daily, underscoring His commitment to persuasion rather than coercion.'
+      }
+    ]
+  },
+  {
+    id: 'john-15-22',
+    reference: 'John 15:22',
+    title: 'No Excuse After Hearing Jesus',
+    translation: 'World English Bible',
+    summary: 'Jesus explains that His spoken revelation removes any excuse for unbelief.',
+    keyVerse: 'If I hadn\'t come and spoken to them, they wouldn\'t have sin; but now they have no excuse for their sin.',
+    themes: ['Accountability', 'Witness', 'Light'],
+    category: 'Accountability & Awakening',
+    context: [
+      {
+        heading: 'John 15:20-25',
+        text: `"Remember the word that I said to you... If they persecuted me, they will also persecute you... <span class="focus-text">If I hadn't come and spoken to them, they wouldn't have sin; but now they have no excuse for their sin.</span> He who hates me, hates my Father also... But this happened so that the word may be fulfilled."`
+      }
+    ],
+    analysis: [
+      {
+        title: 'Revelation Increases Responsibility',
+        body: 'Jesus locates guilt in the rejection of His spoken word. Exposure to the message—not secret regeneration—creates accountability.'
+      },
+      {
+        title: 'Hearing Divides Responders',
+        body: 'Those who hear either love or hate the Son. The text assumes a genuine choice in the face of light received.'
+      }
+    ]
+  },
+  {
+    id: 'ezekiel-18-30-32',
+    reference: 'Ezekiel 18:30-32',
+    title: 'Turn and Live',
+    translation: 'World English Bible',
+    summary: 'God commands Israel to repent, affirming He has no pleasure in anyone’s death.',
+    keyVerse: 'Repent, and turn yourselves from all your transgressions... For I have no pleasure in the death of him who dies.',
+    themes: ['Repentance', 'Life', 'Responsibility'],
+    category: 'Respond in Faith',
+    context: [
+      {
+        heading: 'Ezekiel 18:30-32',
+        text: `"Repent, and turn yourselves from all your transgressions, so iniquity will not be your ruin. <span class="focus-text">Cast away from you all your transgressions that you have committed, and make yourselves a new heart and a new spirit. For why will you die, house of Israel? For I have no pleasure in the death of him who dies," says the Lord Yahweh. "Therefore turn yourselves, and live!"</span>`
+      }
+    ],
+    analysis: [
+      {
+        title: 'God Invites Real Turning',
+        body: 'The imperative to repent assumes the people can respond. God pleads for their life, indicating genuine desire for their repentance.'
+      },
+      {
+        title: 'Death Is Not God’s Preference',
+        body: 'The Lord explicitly denies pleasure in death, countering notions that He unilaterally ordains some to remain hardened.'
+      }
+    ]
+  },
+  {
+    id: 'deuteronomy-30-11-20',
+    reference: 'Deuteronomy 30:11-20',
+    title: 'The Word Is Near You—Choose Life',
+    translation: 'World English Bible',
+    summary: 'Moses assures Israel that the command is near, urging them to choose life by loving and obeying God.',
+    keyVerse: 'The word is very near to you, in your mouth and in your heart, that you may do it.',
+    themes: ['Choice', 'Obedience', 'Blessing'],
+    category: 'Respond in Faith',
+    context: [
+      {
+        heading: 'Deuteronomy 30:11-20',
+        text: `<span class="focus-text">For this commandment which I command you today is not too hard for you, nor is it far off... The word is very near to you, in your mouth and in your heart, that you may do it.</span> ... I have set before you life and death, the blessing and the curse. Therefore choose life, that you may live, you and your descendants.`
+      }
+    ],
+    analysis: [
+      {
+        title: 'Accessibility of the Word',
+        body: 'Moses dismantles excuses. The word is near, accessible for obedience. Paul later quotes this in Romans 10 to explain the gospel proclamation.'
+      },
+      {
+        title: 'Choose Life',
+        body: 'The people are commanded to choose life. Divine desire is for their responsive love, not predetermined rebellion.'
+      }
+    ]
+  },
+  {
+    id: 'ephesians-5-14',
+    reference: 'Ephesians 5:14',
+    title: 'Awake, Rise, and Receive Christ’s Light',
+    translation: 'World English Bible',
+    summary: 'Paul cites a hymn urging sleepers to awaken so that Christ will shine upon them.',
+    keyVerse: 'Awake, you who sleep, and arise from the dead, and Christ will shine on you.',
+    themes: ['Awakening', 'Light', 'Response'],
+    category: 'Accountability & Awakening',
+    context: [
+      {
+        heading: 'Ephesians 5:11-14',
+        text: `Have no fellowship with the unfruitful works of darkness, but rather even reprove them... But all things, when they are reproved, are revealed by the light, for everything that reveals is light. <span class="focus-text">Therefore he says, "Awake, you who sleep, and arise from the dead, and Christ will shine on you."</span>`
+      }
+    ],
+    analysis: [
+      {
+        title: 'Call to Respond to Light',
+        body: 'The summons assumes sleepers can awaken. Christ’s shining follows the responsive act, not a hidden regeneration.'
+      },
+      {
+        title: 'Exposure Through Proclamation',
+        body: 'Light exposes deeds when proclamation reveals them, showing the ministry of the word that awakens listeners to repent.'
+      }
+    ]
+  },
+  {
+    id: '2-corinthians-5-18-21',
+    reference: '2 Corinthians 5:18-21',
+    title: 'Ambassadors Plead: Be Reconciled to God',
+    translation: 'World English Bible',
+    summary: 'God entrusts the message of reconciliation to ambassadors who implore hearers to respond.',
+    keyVerse: 'We beg you on behalf of Christ, be reconciled to God.',
+    themes: ['Reconciliation', 'Mission', 'Appeal'],
+    category: 'Mission & Mediation',
+    context: [
+      {
+        heading: '2 Corinthians 5:17-21',
+        text: `Therefore if anyone is in Christ, he is a new creation... <span class="focus-text">We are therefore ambassadors on behalf of Christ, as though God were entreating by us. We beg you on behalf of Christ, be reconciled to God.</span> For him who knew no sin he made to be sin on our behalf, so that in him we might become the righteousness of God.`
+      }
+    ],
+    analysis: [
+      {
+        title: 'God Appeals Through People',
+        body: 'Reconciliation is offered through human ambassadors who plead. The language of begging shows that God honors genuine persuasion, not automatic regeneration.'
+      },
+      {
+        title: 'Anyone May Be a New Creation',
+        body: 'The promise extends to anyone in Christ, inviting all hearers to respond to the message.'
+      }
+    ]
+  },
+  {
+    id: '1-timothy-2-3-6',
+    reference: '1 Timothy 2:3-6',
+    title: 'God Desires All to Be Saved',
+    translation: 'World English Bible',
+    summary: 'Paul anchors prayer and mission in God’s desire for all people to come to the knowledge of the truth.',
+    keyVerse: 'God our Savior desires all people to be saved and come to full knowledge of the truth.',
+    themes: ['God’s Heart', 'Intercession', 'Truth'],
+    category: 'Mission & Mediation',
+    context: [
+      {
+        heading: '1 Timothy 2:1-6',
+        text: `I exhort therefore, first of all, that petitions, prayers, intercessions, and giving of thanks be made for all people... <span class="focus-text">This is good and acceptable in the sight of God our Savior, who desires all people to be saved and come to full knowledge of the truth.</span> For there is one God, and one mediator between God and men, the man Christ Jesus, who gave himself as a ransom for all.`
+      }
+    ],
+    analysis: [
+      {
+        title: 'Universal Saving Desire',
+        body: 'God’s stated desire challenges limited atonement. His heart beats for all to be saved, aligning with a genuine offer through hearing the truth.'
+      },
+      {
+        title: 'Prayer Fuels Mission',
+        body: 'Intercession for all people makes sense only if all can respond to the mediator. The passage motivates evangelistic prayer and proclamation.'
+      }
+    ]
+  }
+];
+
+export default scriptures;

--- a/src/scripts/index.js
+++ b/src/scripts/index.js
@@ -1,0 +1,153 @@
+import scriptures from '../data/scriptures.js';
+import {
+  getScriptureById,
+  getFeaturedScriptures,
+  createElement,
+  formatThemes,
+} from './utils.js';
+
+const heroHighlightIds = ['isaiah-55-1-3', 'john-20-30-31', 'ephesians-1-13-14'];
+const narrativeSections = [
+  {
+    title: 'A Call to Listen',
+    description:
+      'From the prophets onward, God pleads with His people to incline their ear. The invitation is open, the covenant is relational, and responsibility is real.',
+    scriptureId: 'deuteronomy-30-11-20',
+  },
+  {
+    title: 'Prophets Summon Repentance',
+    description:
+      'Jeremiah and Ezekiel call the people to turn back, assuring them that the Lord takes no pleasure in death but delights when the wicked repent and live.',
+    scriptureId: 'ezekiel-18-30-32',
+  },
+  {
+    title: 'Messiah Announces Good News',
+    description:
+      'Jesus proclaims life to all who believe, promising new birth through trust in His name. Hearing produces belief, and belief receives life.',
+    scriptureId: 'john-20-30-31',
+  },
+  {
+    title: 'Apostles Preach for Faith',
+    description:
+      'From Pentecost to Philippi, the Spirit moves as the word is proclaimed. Hearts are cut, households rejoice, and the Spirit falls when the message is heard.',
+    scriptureId: 'acts-2-37-38',
+  },
+  {
+    title: 'Hearing, Believing, Sealed',
+    description:
+      'Paul anchors assurance in the moment we hear the gospel, believe, and are sealed with the promised Spirit—no secret regeneration required beforehand.',
+    scriptureId: 'ephesians-1-13-14',
+  },
+];
+
+const categoryDetails = [
+  {
+    label: 'Hear and Believe',
+    description: 'Passages where hearing the proclaimed word becomes the spark for genuine belief.',
+  },
+  {
+    label: 'Respond in Faith',
+    description: 'Texts that invite hearers to repent, trust, and actively choose life in Christ.',
+  },
+  {
+    label: 'Spirit & New Life',
+    description: 'Moments showing the Spirit given through the heard word, bringing new birth and assurance.',
+  },
+  {
+    label: 'Mission & Mediation',
+    description: 'Witness-bearing passages where ambassadors partner with God to carry the invitation.',
+  },
+  {
+    label: 'Accountability & Awakening',
+    description: 'Warnings that reveal the responsibility that comes with receiving light and testimony.',
+  },
+];
+
+const spotlightContainer = document.querySelector('#spotlight-grid');
+const heroGrid = document.querySelector('#hero-grid');
+const timeline = document.querySelector('#timeline');
+
+function escapeAttribute(value) {
+  return value.replace(/&/g, '&amp;').replace(/"/g, '&quot;');
+}
+
+function renderHeroHighlights() {
+  const highlights = getFeaturedScriptures(heroHighlightIds);
+  highlights.forEach((entry, index) => {
+    const card = createElement('div', { classes: ['glass-card', 'fade-in'] });
+    card.style.animationDelay = `${index * 0.15}s`;
+    card.innerHTML = `
+      <div class="badge">${entry.reference}</div>
+      <h3>${entry.summary}</h3>
+      <p>${entry.keyVerse}</p>
+      <a href="scripture.html?id=${entry.id}">Read the full study →</a>
+    `;
+    heroGrid.appendChild(card);
+  });
+}
+
+function renderTimeline() {
+  narrativeSections.forEach((section) => {
+    const passage = getScriptureById(section.scriptureId);
+    const item = createElement('div', { classes: 'timeline-item' });
+    const bullet = createElement('div', { classes: 'timeline-bullet' });
+    const content = createElement('div', { classes: 'story-card' });
+    const title = createElement('h3', { text: section.title });
+    const description = createElement('p', { text: section.description });
+    const link = createElement('a', {
+      html: `Explore ${passage.reference} →`,
+      attrs: { href: `scripture.html?id=${passage.id}` },
+      classes: 'text-muted',
+    });
+
+    content.append(title, description, link);
+    item.append(bullet, content);
+    timeline.appendChild(item);
+  });
+}
+
+function renderSpotlights() {
+  const grouped = scriptures.reduce((acc, entry) => {
+    if (!acc[entry.category]) {
+      acc[entry.category] = [];
+    }
+    acc[entry.category].push(entry);
+    return acc;
+  }, {});
+
+  categoryDetails.forEach(({ label, description }) => {
+    const entries = grouped[label];
+    if (!entries || entries.length === 0) return;
+
+    const section = createElement('section', { classes: 'category-group' });
+    const header = createElement('div', { classes: 'category-header' });
+    header.innerHTML = `
+      <h3>${label}</h3>
+      <p>${description}</p>
+    `;
+
+    const grid = createElement('div', { classes: ['grid', 'scripture-grid', 'category-grid'] });
+
+    entries
+      .sort((a, b) => a.reference.localeCompare(b.reference))
+      .forEach((entry) => {
+        const card = createElement('article', { classes: 'card' });
+        const translationTitle = `Translation: ${entry.translation}`;
+        card.innerHTML = `
+          <div class="badge" title="${escapeAttribute(translationTitle)}">${entry.reference}</div>
+          <h3>${entry.summary}</h3>
+          <p>${entry.keyVerse}</p>
+          <div class="tag-group">${formatThemes(entry.themes)}</div>
+          <a class="back-link" href="scripture.html?id=${entry.id}">Study this passage →</a>
+        `;
+        grid.appendChild(card);
+      });
+
+    section.append(header, grid);
+    spotlightContainer.appendChild(section);
+  });
+}
+
+renderHeroHighlights();
+renderTimeline();
+renderSpotlights();

--- a/src/scripts/scripture.js
+++ b/src/scripts/scripture.js
@@ -1,0 +1,67 @@
+import {
+  getScriptureById,
+  getRelatedScriptures,
+  buildContextHtml,
+  buildAnalysisHtml,
+  createElement,
+  formatThemes,
+} from './utils.js';
+
+const params = new URLSearchParams(window.location.search);
+const id = params.get('id');
+const scripture = id ? getScriptureById(id) : null;
+
+const scriptureBody = document.querySelector('#scripture-body');
+const sidebar = document.querySelector('#sidebar');
+
+if (!scripture) {
+  scriptureBody.innerHTML = `
+    <h1>Passage not found</h1>
+    <p>We couldn't find that study. Please return to the Scripture Spotlights and choose a passage.</p>
+    <a class="back-link" href="index.html#spotlights">← Back to all passages</a>
+  `;
+} else {
+  document.title = `${scripture.reference} Study | Open Invitation`;
+  scriptureBody.innerHTML = `
+    <div class="badge">${scripture.reference} · ${scripture.translation}</div>
+    <h1>${scripture.title}</h1>
+    <p class="text-muted">${scripture.summary}</p>
+    <div class="context-block">${buildContextHtml(scripture.context)}</div>
+    <div class="analysis-section">
+      <h2>Exegetical Reflections</h2>
+      ${buildAnalysisHtml(scripture.analysis)}
+    </div>
+  `;
+
+  const sidebarContent = createElement('div', { classes: 'card' });
+  sidebarContent.innerHTML = `
+    <h3>Key Verse</h3>
+    <p class="focus-text">${scripture.keyVerse}</p>
+    <div class="tag-group" style="margin-top: 1rem;">${formatThemes(scripture.themes)}</div>
+  `;
+
+  const related = getRelatedScriptures(scripture.id, scripture.themes, 5);
+  const relatedWrapper = createElement('div', { classes: 'card' });
+  relatedWrapper.innerHTML = '<h3>Related Studies</h3>';
+
+  if (related.length === 0) {
+    const empty = createElement('p', { text: 'More studies coming soon.' });
+    relatedWrapper.appendChild(empty);
+  } else {
+    const list = createElement('div', { classes: 'related-list' });
+    related.forEach((entry) => {
+      const item = createElement('div', {
+        classes: 'related-card',
+        html: `
+          <strong>${entry.reference}</strong>
+          <p>${entry.summary}</p>
+          <a class="back-link" href="scripture.html?id=${entry.id}">View study →</a>
+        `,
+      });
+      list.appendChild(item);
+    });
+    relatedWrapper.appendChild(list);
+  }
+
+  sidebar.append(sidebarContent, relatedWrapper);
+}

--- a/src/scripts/utils.js
+++ b/src/scripts/utils.js
@@ -1,0 +1,71 @@
+import scriptures from '../data/scriptures.js';
+
+export function getScriptureById(id) {
+  return scriptures.find((entry) => entry.id === id);
+}
+
+export function getFeaturedScriptures(ids) {
+  return scriptures.filter((entry) => ids.includes(entry.id));
+}
+
+export function getRelatedScriptures(currentId, themes = [], limit = 4) {
+  const matches = scriptures
+    .filter((entry) => entry.id !== currentId)
+    .map((entry) => {
+      const overlap = entry.themes.filter((theme) => themes.includes(theme)).length;
+      return { entry, overlap };
+    })
+    .sort((a, b) => b.overlap - a.overlap || a.entry.reference.localeCompare(b.entry.reference));
+
+  return matches
+    .filter(({ overlap }) => overlap > 0)
+    .slice(0, limit)
+    .map(({ entry }) => entry);
+}
+
+export function createElement(tag, options = {}) {
+  const element = document.createElement(tag);
+  if (options.classes) {
+    element.className = Array.isArray(options.classes) ? options.classes.join(' ') : options.classes;
+  }
+  if (options.html) {
+    element.innerHTML = options.html;
+  }
+  if (options.text) {
+    element.textContent = options.text;
+  }
+  if (options.attrs) {
+    Object.entries(options.attrs).forEach(([key, value]) => {
+      element.setAttribute(key, value);
+    });
+  }
+  return element;
+}
+
+export function formatThemes(themes) {
+  return themes.map((theme) => `<span class="chip">${theme}</span>`).join('');
+}
+
+export function buildContextHtml(context) {
+  return context
+    .map(({ heading, text }) => {
+      const headingHtml = heading ? `<strong>${heading}</strong>` : '';
+      return `<p>${headingHtml}${heading ? '<br>' : ''}${text}</p>`;
+    })
+    .join('');
+}
+
+export function buildAnalysisHtml(analysis) {
+  return analysis
+    .map(({ title, body }) => {
+      return `
+        <div class="analysis-section">
+          <h3>${title}</h3>
+          <p>${body}</p>
+        </div>
+      `;
+    })
+    .join('');
+}
+
+export default scriptures;

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -1,0 +1,130 @@
+.hero-glow {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.35), transparent 60%),
+              radial-gradient(circle at 80% 30%, rgba(255, 255, 255, 0.25), transparent 55%),
+              radial-gradient(circle at 50% 80%, rgba(255, 255, 255, 0.2), transparent 60%);
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+.hero-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
+  margin-top: 3rem;
+}
+
+.glass-card {
+  background: rgba(255, 255, 255, 0.22);
+  backdrop-filter: blur(18px);
+  border-radius: 24px;
+  padding: 1.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  color: #fff;
+  position: relative;
+  overflow: hidden;
+}
+
+.glass-card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.3) 0%, rgba(255, 255, 255, 0) 60%);
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.glass-card:hover::after {
+  opacity: 1;
+}
+
+.tag-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.cta-card {
+  display: grid;
+  gap: 1rem;
+  text-align: center;
+}
+
+.cta-card p {
+  margin: 0;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  background: rgba(31, 60, 136, 0.12);
+  padding: 0.35rem 0.7rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-primary);
+}
+
+.commentary-card {
+  background: rgba(31, 60, 136, 0.08);
+  border-radius: 20px;
+  padding: 1.5rem;
+}
+
+.commentary-card h4 {
+  margin-bottom: 0.5rem;
+  font-size: 1.05rem;
+}
+
+.fade-in {
+  opacity: 0;
+  transform: translateY(24px);
+  animation: fadeInUp 0.9s ease forwards;
+}
+
+.fade-in:nth-child(2) {
+  animation-delay: 0.15s;
+}
+
+.fade-in:nth-child(3) {
+  animation-delay: 0.3s;
+}
+
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(24px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.banner {
+  background: linear-gradient(120deg, rgba(43, 75, 139, 0.85), rgba(247, 107, 138, 0.85));
+  color: #fff;
+  padding: 2.5rem;
+  border-radius: 24px;
+  position: relative;
+  overflow: hidden;
+  box-shadow: var(--shadow-soft);
+}
+
+.banner::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top left, rgba(255,255,255,0.35), transparent 55%);
+  opacity: 0.8;
+}
+
+.banner > * {
+  position: relative;
+  z-index: 1;
+}
+

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,0 +1,161 @@
+:root {
+  --color-primary: #2b4b8b;
+  --color-secondary: #f8a15e;
+  --color-accent: #fcd77f;
+  --color-background: #f7f4ef;
+  --color-surface: #ffffff;
+  --color-muted: #6b7280;
+  --color-strong: #1f2933;
+  --gradient-hero: linear-gradient(135deg, #1f3c88 0%, #fbb040 50%, #f76b8a 100%);
+  --font-sans: 'Poppins', 'Helvetica Neue', Arial, sans-serif;
+  --font-serif: 'Merriweather', 'Georgia', serif;
+  --shadow-soft: 0 18px 40px rgba(31, 60, 136, 0.15);
+  --max-width: 1080px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html, body {
+  margin: 0;
+  padding: 0;
+  font-family: var(--font-sans);
+  background: var(--color-background);
+  color: var(--color-strong);
+  scroll-behavior: smooth;
+}
+
+a {
+  color: var(--color-primary);
+  text-decoration: none;
+  transition: color 0.2s ease, text-shadow 0.2s ease;
+}
+
+a:hover,
+a:focus {
+  color: var(--color-secondary);
+  text-shadow: 0 0 4px rgba(248, 161, 94, 0.35);
+}
+
+h1, h2, h3, h4 {
+  font-family: var(--font-serif);
+  margin: 0 0 0.75rem;
+  line-height: 1.2;
+}
+
+p {
+  margin: 0 0 1rem;
+  line-height: 1.7;
+}
+
+button {
+  font-family: inherit;
+  border: none;
+  border-radius: 999px;
+  padding: 0.75rem 1.75rem;
+  background: var(--color-primary);
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: var(--shadow-soft);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 22px 44px rgba(31, 60, 136, 0.25);
+}
+
+main {
+  display: block;
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+}
+
+.highlight {
+  background: var(--color-accent);
+  padding: 0.1rem 0.2rem;
+  border-radius: 0.3rem;
+}
+
+.focus-text {
+  background: rgba(248, 161, 94, 0.25);
+  border-left: 4px solid var(--color-secondary);
+  padding: 0.35rem 0.5rem;
+  display: inline;
+  box-decoration-break: clone;
+}
+
+.text-muted {
+  color: var(--color-muted);
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  padding: 0.35rem 0.9rem;
+  background: rgba(31, 60, 136, 0.1);
+  color: var(--color-primary);
+  font-size: 0.85rem;
+  font-weight: 600;
+  margin: 0 0.35rem 0.35rem 0;
+}
+
+.section-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 0.75rem;
+  color: var(--color-muted);
+  font-weight: 600;
+  margin-bottom: 0.4rem;
+}
+
+.card {
+  background: var(--color-surface);
+  border-radius: 24px;
+  padding: 2rem;
+  box-shadow: var(--shadow-soft);
+  position: relative;
+  overflow: hidden;
+}
+
+.card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0) 0%, rgba(247, 212, 136, 0.35) 100%);
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.card:hover::after {
+  opacity: 1;
+}
+
+.grid {
+  display: grid;
+  gap: 2rem;
+}
+
+.flow > * + * {
+  margin-top: 1.5rem;
+}
+
+@media (max-width: 768px) {
+  h1 {
+    font-size: 2rem;
+  }
+
+  .card {
+    padding: 1.5rem;
+  }
+}
+

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -1,0 +1,268 @@
+.header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  backdrop-filter: blur(12px);
+  background: rgba(247, 244, 239, 0.85);
+  border-bottom: 1px solid rgba(31, 60, 136, 0.08);
+}
+
+.header-inner {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 1rem 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.brand {
+  font-weight: 700;
+  font-size: 1.25rem;
+  letter-spacing: 0.04em;
+}
+
+.nav-links {
+  display: flex;
+  gap: 1.25rem;
+  align-items: center;
+}
+
+.hero {
+  background: var(--gradient-hero);
+  color: #fff;
+  padding: 6rem 1.5rem 7rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.hero::after {
+  content: "";
+  position: absolute;
+  inset: 10% 20% auto;
+  height: 320px;
+  background: radial-gradient(circle at top, rgba(255,255,255,0.55), rgba(255,255,255,0));
+  filter: blur(30px);
+}
+
+.hero-content {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  position: relative;
+  z-index: 1;
+}
+
+.hero h1 {
+  font-size: 3.1rem;
+  max-width: 720px;
+}
+
+.hero p {
+  max-width: 640px;
+  font-size: 1.1rem;
+}
+
+.hero-actions {
+  margin-top: 2rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.section {
+  padding: 5rem 1.5rem;
+}
+
+.section-inner {
+  max-width: var(--max-width);
+  margin: 0 auto;
+}
+
+.timeline {
+  position: relative;
+  margin-top: 3rem;
+  padding-left: 1.5rem;
+}
+
+.timeline::before {
+  content: "";
+  position: absolute;
+  left: 0.35rem;
+  top: 0;
+  bottom: 0;
+  width: 3px;
+  background: linear-gradient(to bottom, rgba(31, 60, 136, 0.45), rgba(248, 161, 94, 0.6));
+}
+
+.timeline-item {
+  position: relative;
+  margin-bottom: 2.5rem;
+  padding-left: 1.5rem;
+}
+
+.timeline-bullet {
+  position: absolute;
+  left: -0.05rem;
+  top: 0.3rem;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #fff;
+  border: 4px solid var(--color-secondary);
+  box-shadow: 0 0 0 4px rgba(248, 161, 94, 0.25);
+}
+
+.spotlight-groups {
+  display: flex;
+  flex-direction: column;
+  gap: 3rem;
+  margin-top: 2rem;
+}
+
+.category-group {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.category-header h3 {
+  margin-bottom: 0.35rem;
+}
+
+.category-header p {
+  margin: 0;
+  max-width: 60ch;
+  color: var(--color-muted);
+}
+
+.category-grid {
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.scripture-grid {
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  margin-top: 0;
+}
+
+.story-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.story-card strong {
+  font-family: var(--font-serif);
+  font-size: 1.1rem;
+}
+
+.footer {
+  background: #111827;
+  color: rgba(255,255,255,0.85);
+  padding: 3rem 1.5rem;
+}
+
+.footer-inner {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.footer-links {
+  display: flex;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.footer a {
+  color: rgba(255,255,255,0.85);
+}
+
+@media (max-width: 768px) {
+  .nav-links {
+    display: none;
+  }
+
+  .hero {
+    padding: 5rem 1.25rem 6rem;
+  }
+
+  .timeline {
+    padding-left: 1rem;
+  }
+
+  .timeline-item {
+    padding-left: 1rem;
+  }
+}
+
+.scripture-layout {
+  display: grid;
+  gap: 2.5rem;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+}
+
+.scripture-body {
+  background: var(--color-surface);
+  border-radius: 24px;
+  padding: 2.5rem;
+  box-shadow: var(--shadow-soft);
+}
+
+.scripture-body h1 {
+  font-size: 2.4rem;
+}
+
+.context-block {
+  margin-top: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 20px;
+  background: rgba(31, 60, 136, 0.05);
+}
+
+.context-block p {
+  font-family: var(--font-serif);
+  white-space: pre-line;
+}
+
+.analysis-section {
+  margin-top: 2.5rem;
+  border-top: 1px solid rgba(31, 60, 136, 0.15);
+  padding-top: 2rem;
+}
+
+.analysis-section h3 {
+  font-size: 1.35rem;
+}
+
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.related-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.related-card {
+  border-left: 4px solid var(--color-secondary);
+  padding-left: 1rem;
+}
+
+.back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-weight: 600;
+}
+
+@media (max-width: 992px) {
+  .scripture-layout {
+    grid-template-columns: 1fr;
+  }
+}
+


### PR DESCRIPTION
## Summary
- document the scripture explorer vision, information architecture, and roadmap in `docs/PLAN.md`
- implement a narrative-driven landing page with dynamic scripture spotlights powered by modular scripts and styles
- build a scripture explorer view backed by a reusable dataset of twenty-plus passages emphasizing faith-through-hearing themes
- organize the spotlight tiles into theological categories with translation tooltips and add studies for John 15:22 and Ephesians 5:14

## Testing
- `node -e "import('./src/data/scriptures.js').then(m=>console.log(m.default.length));"`


------
https://chatgpt.com/codex/tasks/task_e_68dfbd44b8d4832d80fb74d92887c79b